### PR TITLE
Add documentation on how to write tests for custom rules.

### DIFF
--- a/data/docs/custom-rule.md
+++ b/data/docs/custom-rule.md
@@ -114,6 +114,56 @@ rector.php
 composer.json
 ```
 
+### Writing tests
+
+Rector provides a structured way of running your rules on snippets of code so you can validate that your rule works as expected.
+It uses PHPUnit to run the tests and `rector/rector` provides the `AbstractRectorTestCase` class to simplify test configuration.
+
+The usual structure of the test class is as follows:
+```php
+declare(strict_types=1);
+
+namespace Utils\Rector\Tests\Rector\MyFirstRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MyFirstRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}
+```
+
+You can see that there are 3 functions in this test class:
+
+- `public function test(string $filePath): void`:
+  - This method is to help PHPUnit detect this test
+  - For `$filePath`, we use a [PHPUnit DataProvider](https://phpunit.readthedocs.io/en/10.0/writing-tests-for-phpunit.html#data-providers)
+  - This triggers a run for every test file in your Fixtures directory
+- `public static function provideData(): Iterator`:
+  - As stated above, this is a PHPUnit DataProvider
+  - Using `self::yieldFilesFromDirectory` it iterates over all test cases you provided
+  - See `How To Add Test Case` for the files that are expected in the `/Fixture` directory
+- `public function provideConfigFilePath(): Iterator`:
+  - This should return a `rector.php`-styled file configuring the minimal set of rules needed to run the tests (including `MyFirstRectorRule`)
+
+You can run your tests with `vendor/bin/phpunit utils/rector/tests`
+
 ## Update `composer.json`
 
 We also need to load Rector rules in `composer.json`:

--- a/data/docs/custom-rule.md
+++ b/data/docs/custom-rule.md
@@ -114,56 +114,6 @@ rector.php
 composer.json
 ```
 
-### Writing tests
-
-Rector provides a structured way of running your rules on snippets of code so you can validate that your rule works as expected.
-It uses PHPUnit to run the tests and `rector/rector` provides the `AbstractRectorTestCase` class to simplify test configuration.
-
-The usual structure of the test class is as follows:
-```php
-declare(strict_types=1);
-
-namespace Utils\Rector\Tests\Rector\MyFirstRector;
-
-use Iterator;
-use PHPUnit\Framework\Attributes\DataProvider;
-use Rector\Testing\PHPUnit\AbstractRectorTestCase;
-
-final class MyFirstRectorTest extends AbstractRectorTestCase
-{
-    #[DataProvider('provideData')]
-    public function test(string $filePath): void
-    {
-        $this->doTestFile($filePath);
-    }
-
-    public static function provideData(): Iterator
-    {
-        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
-    }
-
-    public function provideConfigFilePath(): string
-    {
-        return __DIR__ . '/config/configured_rule.php';
-    }
-}
-```
-
-You can see that there are 3 functions in this test class:
-
-- `public function test(string $filePath): void`:
-  - This method is to help PHPUnit detect this test
-  - For `$filePath`, we use a [PHPUnit DataProvider](https://phpunit.readthedocs.io/en/10.0/writing-tests-for-phpunit.html#data-providers)
-  - This triggers a run for every test file in your Fixtures directory
-- `public static function provideData(): Iterator`:
-  - As stated above, this is a PHPUnit DataProvider
-  - Using `self::yieldFilesFromDirectory` it iterates over all test cases you provided
-  - See `How To Add Test Case` for the files that are expected in the `/Fixture` directory
-- `public function provideConfigFilePath(): Iterator`:
-  - This should return a `rector.php`-styled file configuring the minimal set of rules needed to run the tests (including `MyFirstRectorRule`)
-
-You can run your tests with `vendor/bin/phpunit utils/rector/tests`
-
 ## Update `composer.json`
 
 We also need to load Rector rules in `composer.json`:

--- a/data/docs/writing-tests-for-custom-rule.md
+++ b/data/docs/writing-tests-for-custom-rule.md
@@ -1,0 +1,182 @@
+Writing test for your custom rules will save you a lot of time in future debugging.
+Rector provides a structured way of running your rules on different snippets of code
+so you can validate that your rule works as expected in a variety of cases.
+
+## Requirements
+
+There are 2 composer packages that you need to write & run tests for your custom rule:
+* `phpunit/phpunit`: The test framework
+* `rector/rector`: This contains the `AbstractRectorTestCase` class to simplify test configuration
+To run the Rector default test structure, you need to have [PHPUnit](https://docs.phpunit.de/en/10.0/installation.html#composer) installed in your project.
+
+This page assumes you have PHPUnit installed through composer.
+
+## File Structure
+
+Here is an example file structure for testing:
+
+```bash
+/src
+    /Rector
+        MyFirstRector.php
+/tests
+    /Rector
+        /MyFirstRector
+            /Fixture
+                test_fixture.php.inc
+                skip_rule_test_fixture.php.inc
+            /config
+                config.php
+            MyFirstRectorTest.php
+```
+
+The files in `tests/Rector/MyFirstRector` will be explained below.
+
+### MyFirstRectorTest.php
+
+This class handles the heavy lifting of preparing Rector & running it against your test cases.
+The usual structure of the test class is as follows:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Package\Tests\Rector\MyFirstRector;
+
+use Iterator;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Rector\Testing\PHPUnit\AbstractRectorTestCase;
+
+final class MyFirstRectorTest extends AbstractRectorTestCase
+{
+    #[DataProvider('provideData')]
+    public function test(string $filePath): void
+    {
+        $this->doTestFile($filePath);
+    }
+
+    public static function provideData(): Iterator
+    {
+        return self::yieldFilesFromDirectory(__DIR__ . '/Fixture');
+    }
+
+    public function provideConfigFilePath(): string
+    {
+        return __DIR__ . '/config/configured_rule.php';
+    }
+}
+```
+
+You can see that there are 3 functions in this test class:
+
+- `public function test(string $filePath): void`:
+  - This method is to help PHPUnit detect this test
+  - For `$filePath`, we use a [PHPUnit DataProvider](https://phpunit.readthedocs.io/en/10.0/writing-tests-for-phpunit.html#data-providers)
+  - This triggers a run for every test file in your Fixtures directory
+- `public static function provideData(): Iterator`:
+  - As stated above, this is a PHPUnit DataProvider
+  - Using `self::yieldFilesFromDirectory` it iterates over all test cases you provided
+    - By default this only picks up files ending on `.php.inc`, see the `AbstractRectorTestCase` to see how you can change this.
+    - See "Fixtures/*.php.inc" below for the files that are expected in the `/Fixture` directory
+  - In the example file structure earlier, this would result in `test_fixture.php.inc` and `skip_rule_test_fixture.php.inc`
+- `public function provideConfigFilePath(): Iterator`:
+  - This should return a `rector.php`-styled file configuring the minimal set of rules needed to run the tests (including `MyFirstRectorRule`)
+  - See "config/config.php" below for an example
+
+### config/config.php
+
+This is a `rector.php`-styled file. If your rule is not configurable, it will look like this:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Package\MyFirstRector;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->rule(MyFirstRector::class);
+};
+```
+
+This essentially reflects how you would use your rule in real life.
+
+### Fixture/*.php.inc
+
+As mentioned in `MyFirstRectorTest.php`, these are the snippets of code on which Rector will run your custom rule.
+To prevent automated tools from picking up those snippets, you need to add an extra suffix `.inc` (so `example.php` should be `example.php.inc`).
+
+There are two options for every test file: Either the snippet should be changed by your rule or it should stay the same.
+
+#### Fixture/test_fixture.php.inc
+
+Assuming your rector rule changes `$user->setPassword('123456')` to `$user->changePassword('123456')`,
+this is an example snippet:
+
+```php
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+class SomeClass
+{
+    public function handlePasswordChange(User $user, string $password)
+    {
+        $user->setPassword($password);
+    }
+}
+
+?>
+-----
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+class SomeClass
+{
+    public function handlePasswordChange(User $user, string $password)
+    {
+        $user->changePassword($password);
+    }
+}
+
+?>
+```
+
+This file contains a "before" and "after" situation, separated by exactly 5 dashes: `-----`.
+The `AbstractRectorTestCase` detects the `-----`
+and will run the rules configured in `config/config.php` on the snippet of code before the `-----`
+and assert that the changed file exactly matches the snippet of code after the `-----`.
+
+#### Fixture/skip_rule_test_fixture.php.inc
+
+There are cases where you might want to check that your rule is **not** applied.
+The file structure is very similar to the `Fixture/test_fixture.php.inc` with 1 exception:
+It only contains a "before" situation.
+
+It is not necessary to prefix the fixture with `skip`, but doing so makes it easy to see that no changes are expected.
+
+Example snippet:
+```php
+<?php
+
+namespace Package\Tests\Rector\MyFirstRector\Fixture;
+
+class SomeClass
+{
+    public function handleLogin(User $user, string $password)
+    {
+        return $user->isCorrectPassword($password);
+    }
+}
+
+?>
+```
+
+As you see, there is no `-----`, so `AbstractRectorTestCase` will run the rules in `config/config.php` on the snippet
+and assert that there are no changes applied to the snippet.
+
+## Running your tests
+
+You can run your tests with `vendor/bin/phpunit tests`

--- a/src/Documentation/DocumentationMenuFactory.php
+++ b/src/Documentation/DocumentationMenuFactory.php
@@ -39,6 +39,7 @@ final class DocumentationMenuFactory
         $documentationSection['Advanced'] = [
             new DocumentationSection('how-rector-works', 'How Rector Works'),
             new DocumentationSection('custom-rule', 'Custom Rule'),
+            new DocumentationSection('writing-tests-for-custom-rule', 'Writing Tests For Custom Rule'),
             new DocumentationSection('rules-overview', 'Rules Overview'),
         ];
 


### PR DESCRIPTION
I noticed while I was creating a custom rule that there was no good documentation on how to write tests, only a recommended file structure without clarification. There is an implicit expectation that tests are simply copied from existing rules.

It is debatable whether this needs to be documented explicitly, because documentation can get out of date, or whether the documentation for recommended file structure should explicitly mention the expectation of copying from existing rules. If you prefer to not document writing tests for custom rules, let me know and I'll create a PR for making the expectation explicit.

While describing `provideData`, I wanted to link to another page (How to add test case) as the structure and logic of the Fixture files was already described elsewhere. However, there is no prior example of this and I'm unsure what the preferred approach is. Possible options for linking are:
- Full absolute URL to the .md file on GitHub
  - Advantage: Will always work as long as repository stays at same location
  - Downside: getrector.com documentation redirects to GitHub. Also makes it harder to provide correctly linking versioned documentation
- Full absolute URL to the rendered documentation at https://getrector.com/documentation/
  - Advantage: Will always work, provides the "nicer" documentation interface
  - Downside: URL has to be hardcoded, making it harder to provide correctly linking versioned documentation later or to migrate to a different URL / subroot
- Relative URL to the .md file
  - Advantage: Easier to implement, supports migrating repository and versioned documentation, better support for local development
  - Downside: Broken link on getrector.com
  - Possible improvement to fix downside: Implement extra logic in `HTMLFromMarkdownFactory` to convert relative URLs to .md files
- Relative URL to the rendered documentation
  - Advantage: Still easy to implement, supports migrating to different URL / subroots and versioned documentation if rendered documentation is published as versions
  - Downside: Broken link in GitHub
- Keep as-is: Least effort but worst developer experience