### PR TITLE
Rename the "How to add test case" page

### DIFF
--- a/data/docs/reporting-issue-with-rector.md
+++ b/data/docs/reporting-issue-with-rector.md
@@ -1,3 +1,6 @@
+Whenever you encounter a situation where Rector does not behave as expected, please create a pull request with a test case that shows what you expected and rector misbehaving.
+When someone is working on fixing this issue, the test case will make it easy to see whether the issue is actually fixed.
+
 ## 1. Create an environment for testing
 
 When using Rector to update your own code, you will typically be using release repository installed by composer, however, when adding tests, you will need to use the development repository as shown:

--- a/src/Documentation/DocumentationMenuFactory.php
+++ b/src/Documentation/DocumentationMenuFactory.php
@@ -33,7 +33,7 @@ final class DocumentationMenuFactory
         $documentationSection['Testing and CI'] = [
             new DocumentationSection('cache-in-ci', 'Cache in CI'),
             new DocumentationSection('troubleshooting-parallel', 'Troubleshooting Parallel'),
-            new DocumentationSection('how-to-add-test-case', 'How To Add Test Case'),
+            new DocumentationSection('reporting-issue-with-rector', 'Reporting Issue With Rector'),
         ];
 
         $documentationSection['Advanced'] = [


### PR DESCRIPTION
As discussed in #1073 

Also added a leading statement to explain why a test case in a pull request is needed.