### PR TITLE
[Doc] Update documentation to use Laravel code for register custom Node Visitor service

### DIFF
--- a/resources/docs/creating-a-node-visitor.md
+++ b/resources/docs/creating-a-node-visitor.md
@@ -3,11 +3,11 @@ You can add new NodeVisitors to process nodes in the `rector.php` config, make s
 ```php
 use Rector\Config\RectorConfig;
 use My\Rector\Visitor\HelloVisitor;
-use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface; 
-
+use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
 
 return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->services()->set(HelloVisitor::class)->tag(ScopeResolverNodeVisitorInterface::class);
+    $rectorConfig->singleton(HelloVisitor::class);
+    $rectorConfig->tag(HelloVisitor::class, ScopeResolverNodeVisitorInterface::class);
 };
 ```
 
@@ -23,11 +23,10 @@ namespace My\Rector\Visitor;
 use PhpParser\Node;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;
-use Rector\NodeTypeResolver\Node\AttributeKey;
 use Rector\NodeTypeResolver\PHPStan\Scope\Contract\NodeVisitor\ScopeResolverNodeVisitorInterface;
 
-class HelloVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface {
-
+class HelloVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisitorInterface
+{
     public const HELLO_ATTRIBUTE = 'rector_comment';
 
     public function enterNode(Node $node)
@@ -36,8 +35,7 @@ class HelloVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisit
             return null;
         }
 
-        $node->setAttribute(HelloVisitor::HELLO_ATTRIBUTE, 'i was here'));
-
+        $node->setAttribute(HelloVisitor::HELLO_ATTRIBUTE, 'i was here');
         return $node;
     }
 

--- a/resources/docs/creating-a-node-visitor.md
+++ b/resources/docs/creating-a-node-visitor.md
@@ -35,9 +35,8 @@ class HelloVisitor extends NodeVisitorAbstract implements ScopeResolverNodeVisit
             return null;
         }
 
-        $node->setAttribute(HelloVisitor::HELLO_ATTRIBUTE, 'i was here');
+        $node->setAttribute(self::HELLO_ATTRIBUTE, 'i was here');
         return $node;
     }
-
 }
 ```


### PR DESCRIPTION
since we use `Laravel` DI, the `services()->tag()` no longer works, in this PR, I updated to use Laravel code.

```php
    $rectorConfig->singleton(HelloVisitor::class);
    $rectorConfig->tag(HelloVisitor::class, ScopeResolverNodeVisitorInterface::class);
```

It can be merged when next rector released.