### PR TITLE
[Doc] Update generate "rector.php" config via vendor/bin/rector

### DIFF
--- a/resources/docs/introduction.md
+++ b/resources/docs/introduction.md
@@ -19,12 +19,12 @@ Rector works with `rector.php` config file. You can create it manually, or Recto
 
 ```bash
 vendor/bin/rector
-```
 
-For version 0.17.0 and lower specify the the init parameter.
+ No "rector.php" config found. Should we generate it for you? [yes]:
+ > yes
 
-```bash
-vendor/bin/rector init
+
+ [OK] The config is added now. Re-run command to make Rector do the work!
 ```
 
 In `rector.php` you can define paths, rules and sets you want to run on your code:


### PR DESCRIPTION
Mentioning `vendor/bin/rector init` on rector below 0.17 sometime seems unreadable, user just copy paste and create issue why it not working.

Instead, this PR update to use `vendor/bin/rector` and show it will prompt generated config.