### PR TITLE
Update github actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/code_analysis.yaml
+++ b/.github/workflows/code_analysis.yaml
@@ -33,7 +33,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             # see https://github.com/shivammathur/setup-php
             -   uses: shivammathur/setup-php@v2

--- a/.github/workflows/daily_pull_request_automatic_update.yaml
+++ b/.github/workflows/daily_pull_request_automatic_update.yaml
@@ -25,7 +25,7 @@ jobs:
 
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     token: ${{ secrets.ACCESS_TOKEN }}
 

--- a/.github/workflows/rector.yaml
+++ b/.github/workflows/rector.yaml
@@ -11,7 +11,7 @@ jobs:
         steps:
             -
                 if: github.event.pull_request.head.repo.full_name == github.repository
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     # Must be used to trigger workflow after push
                     token: ${{ secrets.ACCESS_TOKEN }}

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -10,7 +10,7 @@ jobs:
     unit_tests:
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@v3
+            -   uses: actions/checkout@v4
 
             -   uses: shivammathur/setup-php@v2
                 with:

--- a/resources/blog/posts/2020/2020-10-05-how-to-make-rector-contribute-your-pull-requests-every-day.md
+++ b/resources/blog/posts/2020/2020-10-05-how-to-make-rector-contribute-your-pull-requests-every-day.md
@@ -62,7 +62,7 @@ jobs:
         if: github.event.pull_request.head.repo.full_name == github.repository
         steps:
             -
-                uses: actions/checkout@v3
+                uses: actions/checkout@v4
                 with:
                     # Solves the not "You are not currently on a branch" problem, see https://github.com/actions/checkout/issues/124#issuecomment-586664611
                     ref: ${{ github.event.pull_request.head.ref }}

--- a/resources/blog/posts/2020/2020-11-30-smooth-upgrade-to-php-8-in-diffs.md
+++ b/resources/blog/posts/2020/2020-11-30-smooth-upgrade-to-php-8-in-diffs.md
@@ -310,7 +310,7 @@ Update `shivammathur/setup-php@v2` in your workflows:
      unit_tests:
          runs-on: ubuntu-latest
          steps:
-             -   uses: actions/checkout@v3
+             -   uses: actions/checkout@v4
              -   uses: shivammathur/setup-php@v2
                  with:
 +                    php-version: 7.4


### PR DESCRIPTION
Current github actions/checkout v3 got error:

```

Download action repository 'actions/checkout@v3' (SHA:f43a0e5ff2bd294095638e18286ca9a3d1956744)
Error: Can't use 'tar -xzf' extract archive file: /home/runner/work/_actions/_temp_4ecd32f5-c361-435e-b74b-7171ccb18414/3c125ce6-395a-4023-acd8-39fc47eba947.tar.gz. return code: 2.
```

Ref https://github.com/rectorphp/rector-src/actions/runs/6074243601/job/16477779233#step:1:35

It reported at:

- https://github.com/actions/checkout/issues/1448

This PR try to update to github actions/checkout v4.