### PR TITLE
Use SetList::TYPE_DECLARATION in demo defaults

### DIFF
--- a/resources/demo/DemoFile.php
+++ b/resources/demo/DemoFile.php
@@ -2,11 +2,17 @@
 
 final class DemoFile
 {
-    public function run()
+    public function run(bool $param)
     {
-        return 5;
+        if ($this->isTrue($param)) {
+            return 5;
+        }
 
-        // we never get here
-        return 10;
+        return '10';
+    }
+
+    private function isTrue($value)
+    {
+        return $value === true;
     }
 }

--- a/resources/demo/demo-config.php
+++ b/resources/demo/demo-config.php
@@ -7,7 +7,7 @@ use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromAssignsRector;
 return static function (RectorConfig $rectorConfig): void {
     // A. run whole set
     $rectorConfig->sets([
-        SetList::DEAD_CODE,
+        SetList::TYPE_DECLARATION,
     ]);
 
     // B. or single rule


### PR DESCRIPTION
I think for an end-user its more suprising and compelling to see rector inferring types instead of detecting/removing dead code