### PR TITLE
[Doc] Use fnmatch() instead of $this->isName($node->name, 'set*') in docuemntation create custom rule

### DIFF
--- a/resources/docs/custom-rule.md
+++ b/resources/docs/custom-rule.md
@@ -47,7 +47,7 @@ final class MyFirstRector extends AbstractRector
         }
 
         // we only care about "set*" method names
-        if (fnmatch('set*', $nodeName, FNM_NOESCAPE)) {
+        if (! fnmatch('set*', $nodeName, FNM_NOESCAPE)) {
             // return null to skip it
             return null;
         }

--- a/resources/docs/custom-rule.md
+++ b/resources/docs/custom-rule.md
@@ -41,8 +41,13 @@ final class MyFirstRector extends AbstractRector
      */
     public function refactor(Node $node): ?Node
     {
+        $nodeName = $this->getName($node->name);
+        if ($nodeName === null) {
+            return null;
+        }
+
         // we only care about "set*" method names
-        if (! $this->isName($node->name, 'set*')) {
+        if (fnmatch('set*', $nodeName, FNM_NOESCAPE)) {
             // return null to skip it
             return null;
         }


### PR DESCRIPTION
@TomasVotruba @staabm Regex support on `isName()` is removed at PR:

- https://github.com/rectorphp/rector-src/pull/4954

This PR update documentation to use directly `fnmatch()`