### PR TITLE
Fix missing semicolon warning on demo config page

### DIFF
--- a/src/Rules/FuncCallRule.php
+++ b/src/Rules/FuncCallRule.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Rector\Website\Rules;
 
 use Closure;
-use Error;
+use PhpParser\Error;
 use Illuminate\Contracts\Validation\ValidationRule;
 use PhpParser\Node;
 use PhpParser\Node\Expr\FuncCall;

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -61,7 +61,7 @@ final class DemoControllerTest extends AbstractTestCase
             'rector_config' => 'The rector config field is required.',
         ]];
 
-         // Invalid PHP syntax (missing semicolon in code box)
+         // Invalid PHP syntax (missing semicolon in config box)
          yield ['<?php print $x; ?>', '<?php return static function() {}', [
             'rector_config' => "PHP code is invalid: Syntax error, unexpected EOF, expecting ';' on line 1",
         ]];

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -61,9 +61,9 @@ final class DemoControllerTest extends AbstractTestCase
             'rector_config' => 'The rector config field is required.',
         ]];
 
-        // invalid php syntax (missing semicolon in config box)
-        yield ['<?php echo "test"; ?>', '<?php return ?>', [
-            'rector_config' => 'PHP code is invalid: Syntax error, unexpected EOF on line 1',
+         // Invalid PHP syntax (missing semicolon in code box)
+         yield ['<?php print $x; ?>', '<?php return static function() {}', [
+            'rector_config' => 'PHP code is invalid: Syntax error, unexpected EOF, expecting \';\' on line 1',
         ]];
 
         // Add dangerous exec() func call

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -55,10 +55,15 @@ final class DemoControllerTest extends AbstractTestCase
             'rector_config' => 'PHP code is invalid: Missing PHP opening tag',
         ]];
 
-        // Invalid PHP syntax (missing semicolon)
+        // Invalid PHP syntax (missing semicolon in code box)
         yield ['<?php print $x', '', [
             'php_contents' => 'PHP code is invalid: Syntax error, unexpected EOF on line 1',
             'rector_config' => 'The rector config field is required.',
+        ]];
+
+        // invalid php syntax (missing semicolon in config box)
+        yield ['<?php echo "test"; ?>', '<?php return ?>', [
+            'rector_config' => 'PHP config should not include func call',
         ]];
 
         // Add dangerous exec() func call

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -63,7 +63,7 @@ final class DemoControllerTest extends AbstractTestCase
 
          // Invalid PHP syntax (missing semicolon in code box)
          yield ['<?php print $x; ?>', '<?php return static function() {}', [
-            'rector_config' => 'PHP code is invalid: Syntax error, unexpected EOF, expecting \';\' on line 1',
+            'rector_config' => "PHP code is invalid: Syntax error, unexpected EOF, expecting ';' on line 1",
         ]];
 
         // Add dangerous exec() func call

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -63,7 +63,7 @@ final class DemoControllerTest extends AbstractTestCase
 
         // invalid php syntax (missing semicolon in config box)
         yield ['<?php echo "test"; ?>', '<?php return ?>', [
-            'rector_config' => 'PHP config should not include func call',
+            'rector_config' => 'PHP code is invalid: Syntax error, unexpected EOF on line 1',
         ]];
 
         // Add dangerous exec() func call


### PR DESCRIPTION
@staabm this fix https://github.com/rectorphp/getrector-com/issues/2012