### PR TITLE
[Doc] Add missing ; in config example

### DIFF
--- a/resources/docs/how-rector-works.md
+++ b/resources/docs/how-rector-works.md
@@ -66,7 +66,7 @@ then the `setExpectedException` method will be changed to `expectedException`.
 
 use Rector\PHPUnit\Rector\ClassMethod\ExceptionAnnotationRector;
 use Rector\Renaming\Rector\MethodCall\RenameMethodRector;
-use Rector\Config\RectorConfig
+use Rector\Config\RectorConfig;
 use Rector\Renaming\ValueObject\MethodCallRename;
 
 return RectorConfig::configure()


### PR DESCRIPTION
This makes the highlighting colors look unnatural.

<img width="794" alt="スクリーンショット 2024-02-11 9 05 19" src="https://github.com/rectorphp/getrector-com/assets/822086/f4355bd2-44f5-499b-b027-011f47104722">
