### PR TITLE
chore(doc): remove not found demo path

### DIFF
--- a/resources/docs/debugging.md
+++ b/resources/docs/debugging.md
@@ -21,6 +21,6 @@ vendor/bin/rector process src/Controller --dry-run --xdebug
 
 The best way to report a bug is then find the smallest possible `rector.php` config and single file in your project that causes the crash. Do not copy-paste the whole file, it would be miss leading. The crash usually happens on a 5-10 lines of code.
 
-When you identify those, use https://getrector.com/demo to create a reproducer, e.g. like this one: https://getrector.com/demo/15df663f-61de-4f9b-b647-565f53c835f6
+When you identify those, use https://getrector.com/demo to create a reproducer.
 
 Then you can create an an issue or even a tests. Just click on the button on the right under the code.


### PR DESCRIPTION
hey, imho its better to keep it clean of a 404 notif when devs arrived on the page