### PR TITLE
[Demo Validation] Add ShellExecRule rule to avoid `` execution operator usage on rector config input

### DIFF
--- a/src/Http/Request/DemoFormRequest.php
+++ b/src/Http/Request/DemoFormRequest.php
@@ -35,7 +35,6 @@ final class DemoFormRequest extends FormRequest
         $funcCallRule = app()
             ->make(FuncCallRule::class);
 
-        /** @var ShellExecRule $funcCallRule */
         $shellExecRule = app()
             ->make(ShellExecRule::class);
 

--- a/src/Http/Request/DemoFormRequest.php
+++ b/src/Http/Request/DemoFormRequest.php
@@ -7,6 +7,7 @@ namespace Rector\Website\Http\Request;
 use Illuminate\Foundation\Http\FormRequest;
 use Rector\Website\Rules\FuncCallRule;
 use Rector\Website\Rules\HasRectorRule;
+use Rector\Website\Rules\ShellExecRule;
 use Rector\Website\Rules\ShortPhpContentsRule;
 use Rector\Website\Rules\ValidPhpSyntaxRule;
 
@@ -34,13 +35,17 @@ final class DemoFormRequest extends FormRequest
         $funcCallRule = app()
             ->make(FuncCallRule::class);
 
+        /** @var ShellExecRule $funcCallRule */
+        $shellExecRule = app()
+            ->make(ShellExecRule::class);
+
         /** @var HasRectorRule $hasRectorRule */
         $hasRectorRule = app()
             ->make(HasRectorRule::class);
 
         return [
             'php_contents' => ['required', 'string', $shortPhpContentsRule, $validPhpSyntaxRule],
-            'rector_config' => ['required', 'string', $validPhpSyntaxRule, $funcCallRule, $hasRectorRule],
+            'rector_config' => ['required', 'string', $validPhpSyntaxRule, $funcCallRule, $hasRectorRule, $shellExecRule],
         ];
     }
 

--- a/src/Rules/ShellExecRule.php
+++ b/src/Rules/ShellExecRule.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Website\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\Node\Expr\ShellExec;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+
+final class ShellExecRule implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+
+        try {
+            $stmts = $parser->parse($value);
+            $nodeFinder = new NodeFinder();
+
+            $hasFuncCall = $nodeFinder->findFirst(
+                (array) $stmts,
+                static fn (Node $subNode): bool => $subNode instanceof ShellExec
+            );
+
+            if ($hasFuncCall !== null) {
+                $fail('PHP config should not include execution operator');
+            }
+        } catch (Error $error) {
+            $fail(sprintf('PHP code is invalid: %s', $error->getMessage()));
+        }
+    }
+}

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -71,6 +71,11 @@ final class DemoControllerTest extends AbstractTestCase
             'rector_config' => 'PHP config should not include func call',
         ]];
 
+        // Add dangerous `` execution operator
+        yield ['<?php echo "test"; ?>', '<?php `dangerous command`; ?>', [
+            'rector_config' => 'PHP config should not include execution operator',
+        ]];
+
         // Add no rule in config
         yield ['<?php echo "test"; ?>', '<?php $rectorConfig->removeUnusedImports(); ?>', [
             'rector_config' => 'PHP config should include at least 1 rector rule',


### PR DESCRIPTION
Avoid user input danger execution operator as `ShellExec`

```php
<?php `dangerous command`; ?>
```

Ref https://www.php.net/manual/en/language.operators.execution.php