### PR TITLE
Add Explore AST Menu page

### DIFF
--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -167,7 +167,7 @@ h2 {
 }
 
 .container {
-    max-width: 55em;
+    max-width: 65em;
     padding-left: 1em;
     padding-right: 1em;
 }

--- a/resources/views/_snippets/menu_items.blade.php
+++ b/resources/views/_snippets/menu_items.blade.php
@@ -16,7 +16,7 @@
 
 <li class="nav-item">
     <a href="{{ action(\Rector\Website\Http\Controller\Ast\AstController::class) }}"
-       class="nav-link">Ast Explorer</a>
+       class="nav-link">Explore AST</a>
 </li>
 
 <li class="nav-item">

--- a/resources/views/_snippets/menu_items.blade.php
+++ b/resources/views/_snippets/menu_items.blade.php
@@ -15,6 +15,11 @@
 </li>
 
 <li class="nav-item">
+    <a href="{{ action(\Rector\Website\Http\Controller\Ast\AstController::class) }}"
+       class="nav-link">Ast Explorer</a>
+</li>
+
+<li class="nav-item">
     <a href="{{ action(\Rector\Website\Http\Controller\ContactController::class) }}"
        class="nav-link">Contact</a>
 </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,7 +47,6 @@ Route::get('demo', DemoController::class);
 Route::post('process-demo', ProcessDemoFormController::class);
 
 // ast
-// hide on production, until it's finished
 Route::get('ast', AstController::class);
 Route::get('ast/{uuid}/{activeNodeId?}', AstDetailController::class);
 Route::post('process-ast', ProcessAstFormController::class);


### PR DESCRIPTION
To show "Explore AST" menu page, to show locally, run:

```
yarn build
```

to get regenerated css.

![Screenshot 2024-04-26 at 01 38 08](https://github.com/rectorphp/getrector-com/assets/459648/c4df6805-8693-45f4-95c8-75da4673b159)
