### PR TITLE
[Docs] Add note for withPreparedSets() on php 7.x

### DIFF
--- a/resources/docs/introduction.md
+++ b/resources/docs/introduction.md
@@ -43,6 +43,14 @@ return RectorConfig::configure()
     ->withPreparedSets(deadCode: true);
 ```
 
+> If you're on PHP 7.x, you need to passed value argument instead, on `deadCode` argument set as first argument:
+> ```php
+>    ->withPreparedSets(true)
+> ```
+>
+> and set other argument position to true if needed.
+
+
 To see preview of suggested changed, run `process` command with `--dry-run` option:
 
 ```bash

--- a/resources/docs/introduction.md
+++ b/resources/docs/introduction.md
@@ -44,8 +44,9 @@ return RectorConfig::configure()
 ```
 
 > If you're on PHP 7.x, you need to passed value argument instead, for `deadCode` set, it is a first argument, so you can define:
-> ```php
->    ->withPreparedSets(true)
+> ```diff
+> -   ->withPreparedSets(deadCode: true)
+> +   ->withPreparedSets(true)
 > ```
 >
 > and set other argument position to true if needed.

--- a/resources/docs/introduction.md
+++ b/resources/docs/introduction.md
@@ -43,7 +43,7 @@ return RectorConfig::configure()
     ->withPreparedSets(deadCode: true);
 ```
 
-> If you're on PHP 7.x, you need to passed value argument instead, on `deadCode` argument set as first argument:
+> If you're on PHP 7.x, you need to passed value argument instead, for `deadCode` set, it is a first argument, so you can define:
 > ```php
 >    ->withPreparedSets(true)
 > ```

--- a/resources/docs/introduction.md
+++ b/resources/docs/introduction.md
@@ -43,14 +43,11 @@ return RectorConfig::configure()
     ->withPreparedSets(deadCode: true);
 ```
 
-> If you're on PHP 7.x, you need to passed value argument instead, for `deadCode` set, it is a first argument, so you can define:
+> If you're on PHP 7.x, you can use `withSets()` instead, for `deadCode` set, so you can define:
 > ```diff
-> -   ->withPreparedSets(deadCode: true)
-> +   ->withPreparedSets(true)
+> -   ->withPreparedSets(deadCode: true);
+> +   ->withSets([SetList::DEAD_CODE]);
 > ```
->
-> and set other argument position to true if needed.
-
 
 To see preview of suggested changed, run `process` command with `--dry-run` option:
 


### PR DESCRIPTION
On php 7.x, the named argument is not yet exists, this update doc to clarify it.

Ref https://github.com/rectorphp/rector/issues/8653
/cc @orionseye