### PR TITLE
Feat: hljs after re render

### DIFF
--- a/resources/views/_snippets/styles.blade.php
+++ b/resources/views/_snippets/styles.blade.php
@@ -23,8 +23,8 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', (event) => {
-        document.querySelectorAll('pre code.language-bash, pre code.language-php, pre code.language-yaml, pre code.language-diff, pre code.language-json').forEach((block) => {
-            hljs.highlightBlock(block);
+        document.querySelectorAll('pre code.language-bash, pre code.language-php, pre code.language-yaml, pre code.language-diff, pre code.language-json').forEach((element) => {
+            hljs.highlightElement(element);
         });
     });
 </script>

--- a/resources/views/base.blade.php
+++ b/resources/views/base.blade.php
@@ -36,12 +36,14 @@
 
         <script>
             // Listen for events dispatched from Livewire components...
-            Livewire.on('rules-filtered', () => {
-                document.querySelectorAll('pre code.language-diff').forEach((block) => {
-                    hljs.highlightBlock(block);
+            document.addEventListener('DOMContentLoaded', function () {
+                document.addEventListener('rules-filtered', () => {
+                    setTimeout(() => {
+                        document.querySelectorAll('pre code.language-diff').forEach((element) => {
+                            hljs.highlightElement(element);
+                        });
+                    }, 0);
                 });
-
-                // alert('555');
             })
         </script>
     </body>


### PR DESCRIPTION
added setTimeout with 0 to run this function after rendering so that it works properly. (POV: I faced this kind of issue a lot after the new update)

also updated `highlightBlock` to `highlightElement` to remove the deprecation warning.


https://github.com/rectorphp/getrector-com/assets/53343069/b6399010-90d5-44b8-bc92-83d94498d8b3

