### PR TITLE
[Demo] Add IncludeRule for demo box config

### DIFF
--- a/src/Request/DemoFormRequest.php
+++ b/src/Request/DemoFormRequest.php
@@ -43,7 +43,6 @@ final class DemoFormRequest extends FormRequest
         $hasRectorRule = app()
             ->make(HasRectorRule::class);
 
-        /** @var IncludeRule $hasRectorRule */
         $includeRule = app()
             ->make(IncludeRule::class);
 

--- a/src/Request/DemoFormRequest.php
+++ b/src/Request/DemoFormRequest.php
@@ -7,6 +7,7 @@ namespace Rector\Website\Request;
 use Illuminate\Foundation\Http\FormRequest;
 use Rector\Website\Validation\Rules\FuncCallRule;
 use Rector\Website\Validation\Rules\HasRectorRule;
+use Rector\Website\Validation\Rules\IncludeRule;
 use Rector\Website\Validation\Rules\ShellExecRule;
 use Rector\Website\Validation\Rules\ShortPhpContentsRule;
 use Rector\Website\Validation\Rules\ValidPhpSyntaxRule;
@@ -42,6 +43,10 @@ final class DemoFormRequest extends FormRequest
         $hasRectorRule = app()
             ->make(HasRectorRule::class);
 
+        /** @var IncludeRule $hasRectorRule */
+        $includeRule = app()
+            ->make(IncludeRule::class);
+
         return [
             'php_contents' => ['required', 'string', $shortPhpContentsRule, $validPhpSyntaxRule],
             'rector_config' => [
@@ -51,6 +56,7 @@ final class DemoFormRequest extends FormRequest
                 $funcCallRule,
                 $hasRectorRule,
                 $shellExecRule,
+                $includeRule
             ],
         ];
     }

--- a/src/Request/DemoFormRequest.php
+++ b/src/Request/DemoFormRequest.php
@@ -43,6 +43,7 @@ final class DemoFormRequest extends FormRequest
         $hasRectorRule = app()
             ->make(HasRectorRule::class);
 
+        /** @var IncludeRule $includeRule */
         $includeRule = app()
             ->make(IncludeRule::class);
 

--- a/src/Validation/Rules/IncludeRule.php
+++ b/src/Validation/Rules/IncludeRule.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Rector\Website\Validation\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use PhpParser\Error;
+use PhpParser\Node;
+use PhpParser\Node\Expr\Include_;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
+
+final class IncludeRule implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $parserFactory = new ParserFactory();
+        $parser = $parserFactory->create(ParserFactory::PREFER_PHP7);
+
+        try {
+            $stmts = $parser->parse($value);
+            $nodeFinder = new NodeFinder();
+
+            $hasFuncCall = $nodeFinder->findFirst(
+                (array) $stmts,
+                static fn (Node $subNode): bool => $subNode instanceof Include_
+            );
+
+            if ($hasFuncCall !== null) {
+                $fail('PHP config should not include include/require usage');
+            }
+        } catch (Error $error) {
+            $fail(sprintf('PHP code is invalid: %s', $error->getMessage()));
+        }
+    }
+}

--- a/tests/Controller/DemoControllerTest.php
+++ b/tests/Controller/DemoControllerTest.php
@@ -76,6 +76,11 @@ final class DemoControllerTest extends AbstractTestCase
             'rector_config' => 'PHP config should not include execution operator',
         ]];
 
+        // include file is dangerous
+        yield ['<?php echo "test"; ?>', '<?php include "index.php"; ?>', [
+            'rector_config' => 'PHP config should not include include/require usage',
+        ]];
+
         // Add no rule in config
         yield ['<?php echo "test"; ?>', '<?php $rectorConfig->removeUnusedImports(); ?>', [
             'rector_config' => 'PHP config should include at least 1 rector rule',


### PR DESCRIPTION
I tried add `include "index.php";` on demo box config, and it got error as it include the index page itself:

**Before**
-------

![Screenshot 2024-06-24 at 20 34 10](https://github.com/rectorphp/getrector-com/assets/459648/f4212cb4-8c03-4510-80c3-46cbaf0d843d)

I add `IncludeRule` to safe it:

**After**
-----

![Screenshot 2024-06-24 at 20 34 45](https://github.com/rectorphp/getrector-com/assets/459648/9df7635e-0fa9-419b-af97-cd2e01edea76)

