### PR TITLE
[Config] Skip _ide_helper.php on rector.php as cause infinite loop

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -22,4 +22,7 @@ return RectorConfig::configure()
         '*/Expected/*',
         // generated
         __DIR__ . '/src/Ast/PhpParser/ClickablePrinter.php',
+
+        // cause infinite loop on local with macOS
+        __DIR__ . '/_ide_helper.php',
     ]);


### PR DESCRIPTION
Tested locally:

**Before** stuck at 69%

```
➜  getrector.org git:(main) vendor/bin/rector process --clear-cache                                            
  74/106 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░░░░░░]  69%
```

**After** make 100%

```
➜  getrector.org git:(skip-ide-helper) vendor/bin/rector process --clear-cache
 105/105 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

                                                                                                                        
 [OK] Rector is done!                                                                                                   
```

It seems generated code for Laravel 11.11.0 and ignored by git so not necessarily to scan:

https://github.com/rectorphp/getrector-com/blob/b3180f9b0f2fa4bf810d437fa657104feaefda23/.gitignore#L40