### PR TITLE
[rule-find] Improve printed config for constant values

### DIFF
--- a/resources/views/homepage/rule-detail.blade.php
+++ b/resources/views/homepage/rule-detail.blade.php
@@ -40,7 +40,7 @@
                             </div>
 
                             @if (!$loop->last)
-                                <hr>
+                                <hr class="mb-5 mt-4">
                             @endif
                         @endforeach
                     @else

--- a/src/RuleFilter/ConfiguredDiffSamplesFactory.php
+++ b/src/RuleFilter/ConfiguredDiffSamplesFactory.php
@@ -36,8 +36,7 @@ final readonly class ConfiguredDiffSamplesFactory
         Assert::fileExists($filePath);
 
         $stmts = $this->simplePhpParser->parseFile($filePath);
-
-        $configuredCodeSampleNews = $this->configConfiguredCodeSampleNews($stmts);
+        $configuredCodeSampleNews = $this->resolveConfiguredCodeSampleNews($stmts);
 
         $configuredDiffSamples = [];
 
@@ -59,7 +58,7 @@ final readonly class ConfiguredDiffSamplesFactory
      * @param Stmt[] $stmts
      * @return New_[]
      */
-    private function configConfiguredCodeSampleNews(array $stmts): array
+    private function resolveConfiguredCodeSampleNews(array $stmts): array
     {
         $nodeFinder = new NodeFinder();
 

--- a/src/RuleFilter/MatchingScoreResolver.php
+++ b/src/RuleFilter/MatchingScoreResolver.php
@@ -13,6 +13,17 @@ final class MatchingScoreResolver
     {
         $score = 0;
 
+        // possible Rector class name search
+        if (substr_count($query, ' ') === 0 && str_ends_with($query, 'Rector')) {
+            if ($ruleMetadata->getRectorClass() === $query) {
+                return 20;
+            }
+
+            if ($ruleMetadata->getRuleShortClass() === $query) {
+                return 10;
+            }
+        }
+
         // resolv equery parts
         $queryParts = Strings::split($query, '#\s+#');
         $queryParts = array_map('strtolower', $queryParts);

--- a/src/RuleFilter/PhpParser/NodeFactory/RectorConfigFactory.php
+++ b/src/RuleFilter/PhpParser/NodeFactory/RectorConfigFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\RuleFilter\PhpParser\NodeFactory;
 
+use App\RuleFilter\PhpParser\NodeVisitor\ConstantToValueNodeVisitor;
 use App\RuleFilter\PhpParser\NodeVisitor\NameImportingNodeVisitor;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
@@ -30,6 +31,12 @@ final class RectorConfigFactory
     public function createConfigured(string $ruleClass, Expr $configurationExpr): array
     {
         $args = [new Arg($this->createRuleClassConstFetch($ruleClass)), new Arg($configurationExpr)];
+
+        // change constant values in args to direct strings
+        $nodeTraverser = new NodeTraverser();
+        $constantToValueNodeVisitor = new ConstantToValueNodeVisitor($ruleClass);
+        $nodeTraverser->addVisitor($constantToValueNodeVisitor);
+        $nodeTraverser->traverse($args);
 
         $withConfiguredMethodCall = new MethodCall($this->createConfigureStaticCall(), 'withConfiguredRule', $args);
         $return = new Return_($withConfiguredMethodCall);

--- a/src/RuleFilter/PhpParser/NodeVisitor/ConstantToValueNodeVisitor.php
+++ b/src/RuleFilter/PhpParser/NodeVisitor/ConstantToValueNodeVisitor.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\RuleFilter\PhpParser\NodeVisitor;
+
+use PhpParser\Node;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\NodeVisitorAbstract;
+
+final class ConstantToValueNodeVisitor extends NodeVisitorAbstract
+{
+    public function __construct(
+        private string $ruleClass
+    ) {
+    }
+
+    public function enterNode(Node $node): ?Node
+    {
+        if (! $node instanceof ClassConstFetch) {
+            return null;
+        }
+
+        if (! $node->class instanceof Name) {
+            return null;
+        }
+
+        if ($node->class->toString() !== 'self') {
+            return null;
+        }
+
+        // replace with value
+        if (! $node->name instanceof Identifier) {
+            return null;
+        }
+
+        $constantReference = $this->ruleClass . '::' . $node->name->toString();
+        $constantValue = constant($constantReference);
+
+        return new String_($constantValue);
+    }
+}

--- a/tests/RuleFilter/PhpParser/Fixture/expected-configured-config.php
+++ b/tests/RuleFilter/PhpParser/Fixture/expected-configured-config.php
@@ -1,0 +1,9 @@
+<?php
+
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withConfiguredRule(SimplifyUselessVariableRector::class, [
+        'only_direct_assign' => false,
+    ]);

--- a/tests/RuleFilter/PhpParser/RectorConfigStmtsPrinterTest.php
+++ b/tests/RuleFilter/PhpParser/RectorConfigStmtsPrinterTest.php
@@ -7,6 +7,13 @@ namespace App\Tests\RuleFilter\PhpParser;
 use App\RuleFilter\PhpParser\NodeFactory\RectorConfigFactory;
 use App\RuleFilter\PhpParser\Printer\RectorConfigStmtsPrinter;
 use App\Tests\AbstractTestCase;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Rector\CodeQuality\Rector\FunctionLike\SimplifyUselessVariableRector;
 use Rector\Php70\Rector\ClassMethod\Php4ConstructorRector;
 
 final class RectorConfigStmtsPrinterTest extends AbstractTestCase
@@ -27,5 +34,22 @@ final class RectorConfigStmtsPrinterTest extends AbstractTestCase
 
         $printedConfig = $this->rectorConfigStmtsPrinter->print($configStmts);
         $this->assertStringEqualsFile(__DIR__ . '/Fixture/expected-config.php', $printedConfig);
+    }
+
+    public function testConfigured(): void
+    {
+        $configurationArray = new Array_([
+            new ArrayItem(new ConstFetch(new Name('false')), new ClassConstFetch(new Name('self'), new Identifier(
+                'ONLY_DIRECT_ASSIGN'
+            ))),
+        ]);
+
+        $configStmts = $this->rectorConfigFactory->createConfigured(
+            SimplifyUselessVariableRector::class,
+            $configurationArray
+        );
+
+        $printedConfig = $this->rectorConfigStmtsPrinter->print($configStmts);
+        $this->assertStringEqualsFile(__DIR__ . '/Fixture/expected-configured-config.php', $printedConfig);
     }
 }

--- a/tests/Validator/ErrorMessageNormalizerTest.php
+++ b/tests/Validator/ErrorMessageNormalizerTest.php
@@ -15,8 +15,6 @@ final class ErrorMessageNormalizerTest extends AbstractTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         $this->errorMessageNormalizer = $this->make(ErrorMessageNormalizer::class);
     }
 


### PR DESCRIPTION
Instead of long constant import with self/class meshup, use simple string :+1: 

![Screenshot from 2024-07-06 15-36-51](https://github.com/rectorphp/getrector-com/assets/924196/55c8f7ac-dcfd-4475-9c06-61186596ed7c)