### PR TITLE
[Validation] Randomize and delete after unused for generated rector config on HasRectorRule

### DIFF
--- a/src/Validation/Rules/HasRectorRule.php
+++ b/src/Validation/Rules/HasRectorRule.php
@@ -6,6 +6,7 @@ namespace App\Validation\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Nette\Utils\Random;
 use PhpParser\Error;
 use Rector\Config\RectorConfig;
 use Rector\Contract\Rector\RectorInterface;
@@ -28,7 +29,8 @@ final class HasRectorRule implements ValidationRule
         try {
             $filesystem = new Filesystem();
 
-            $configFilePath = sys_get_temp_dir() . '/temp-' . bin2hex(random_bytes(16)) . '-rector-config.php';
+            $identifier = Random::generate(20);
+            $configFilePath = sys_get_temp_dir() . '/temp-' . $identifier . '-rector-config.php';
             $filesystem->dumpFile($configFilePath, $value);
 
             $rectorContainer = $this->createFromConfigs([$configFilePath]);

--- a/src/Validation/Rules/HasRectorRule.php
+++ b/src/Validation/Rules/HasRectorRule.php
@@ -37,7 +37,7 @@ final class HasRectorRule implements ValidationRule
             $rectors = $rectorContainer->tagged(RectorInterface::class);
 
             // remove no longer used
-            unlink($configFilePath);
+            $filesystem->remove($configFilePath);
 
             if ((is_countable($rectors) ? count($rectors) : 0) > 0) {
                 return;

--- a/src/Validation/Rules/HasRectorRule.php
+++ b/src/Validation/Rules/HasRectorRule.php
@@ -28,11 +28,14 @@ final class HasRectorRule implements ValidationRule
         try {
             $filesystem = new Filesystem();
 
-            $configFilePath = sys_get_temp_dir() . '/temp-rector-config.php';
+            $configFilePath = sys_get_temp_dir() . '/temp-' . bin2hex(random_bytes(16)) . '-rector-config.php';
             $filesystem->dumpFile($configFilePath, $value);
 
             $rectorContainer = $this->createFromConfigs([$configFilePath]);
             $rectors = $rectorContainer->tagged(RectorInterface::class);
+
+            // remove no longer used
+            unlink($configFilePath);
 
             if ((is_countable($rectors) ? count($rectors) : 0) > 0) {
                 return;


### PR DESCRIPTION
this ensure no overlapped consecutive request on rector demo page, also, if generated config no longer used, directly removed.