### PR TITLE
[Demo] Remove generated directory config on DemoRunner::processFilesContents()

### DIFF
--- a/src/DemoRunner.php
+++ b/src/DemoRunner.php
@@ -70,8 +70,9 @@ final class DemoRunner
     {
         $identifier = Random::generate(20);
 
-        $analyzedFilePath = $this->demoDir . DIRECTORY_SEPARATOR . $identifier . DIRECTORY_SEPARATOR . self::ANALYZED_FILE_NAME;
-        $configPath = $this->demoDir . DIRECTORY_SEPARATOR . $identifier . DIRECTORY_SEPARATOR . self::CONFIG_NAME;
+        $directoryConfig = $this->demoDir . DIRECTORY_SEPARATOR . $identifier . DIRECTORY_SEPARATOR;
+        $analyzedFilePath = $directoryConfig . self::ANALYZED_FILE_NAME;
+        $configPath = $directoryConfig . self::CONFIG_NAME;
 
         // this can be both rector config or rector rule
         // for the latter, append simple config to be part of the file
@@ -80,7 +81,7 @@ final class DemoRunner
         if (str_contains($rectorConfig, 'extends') && str_contains($rectorConfig, AbstractRector::class)) {
             // is Rector rule
             $extraFileContents = $rectorConfig;
-            $extraFilePath = $this->demoDir . DIRECTORY_SEPARATOR . $identifier . DIRECTORY_SEPARATOR . 'CustomRuleRector.php';
+            $extraFilePath = $directoryConfig . 'CustomRuleRector.php';
 
             $rectorClassName = ClassNameResolver::resolveFromFileContents($rectorConfig, $analyzedFilePath);
             $rectorConfig = sprintf(
@@ -97,16 +98,11 @@ final class DemoRunner
             $this->filesystem->dumpFile($extraFilePath, $extraFileContents);
         }
 
-        $temporaryFilePaths = [$analyzedFilePath, $configPath];
-        if ($extraFilePath) {
-            $temporaryFilePaths[] = $extraFilePath;
-        }
-
         $rectorProcess = $this->rectorProcessFactory->create($analyzedFilePath, $configPath, $extraFilePath);
         $rectorProcess->run();
 
-        // remove temporary files
-        $this->filesystem->remove($temporaryFilePaths);
+        // remove temporary directory
+        $this->filesystem->remove($directoryConfig);
 
         // error
         if ($rectorProcess->getExitCode() !== self::EXIT_CODE_SUCCESS) {


### PR DESCRIPTION
DemoRunner currently always create new directory without removal, and only remove files inside it, that cause a lot of empty directories:

![Screenshot 2024-07-17 at 22 19 43](https://github.com/user-attachments/assets/c36c4a2a-5e01-45ef-b307-933f090f1537)

this patch fix it.