### PR TITLE
[validation] Add ShortPhpConfigRule

### DIFF
--- a/src/Request/RectorRunFormRequest.php
+++ b/src/Request/RectorRunFormRequest.php
@@ -9,6 +9,7 @@ use App\Validation\Rules\ForbiddenCallLikeRule;
 use App\Validation\Rules\ForbiddenFuncCallRule;
 use App\Validation\Rules\HasRectorRule;
 use App\Validation\Rules\ShellExecRule;
+use App\Validation\Rules\ShortPhpConfigRule;
 use App\Validation\Rules\ShortPhpContentsRule;
 use App\Validation\Rules\ValidAndSafePhpSyntaxRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -26,6 +27,7 @@ final class RectorRunFormRequest extends FormRequest
     public function rules(): array
     {
         $shortPhpContentsRule = $this->make(ShortPhpContentsRule::class);
+        $shortPhpConfigRule = $this->make(ShortPhpConfigRule::class);
         $validAndSafePhpSyntaxRule = $this->make(ValidAndSafePhpSyntaxRule::class);
 
         $forbiddenFuncCallRule = $this->make(ForbiddenFuncCallRule::class);
@@ -42,6 +44,7 @@ final class RectorRunFormRequest extends FormRequest
                 'required',
                 'string',
                 $validAndSafePhpSyntaxRule,
+                $shortPhpConfigRule,
                 $shellExecRule,
                 $forbiddenFuncCallRule,
                 $forbiddenCallLikeRule,

--- a/src/Validation/Rules/ShortPhpConfigRule.php
+++ b/src/Validation/Rules/ShortPhpConfigRule.php
@@ -4,19 +4,27 @@ declare(strict_types=1);
 
 namespace App\Validation\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 final class ShortPhpConfigRule implements ValidationRule
 {
-    use ShortPhpLinesTrait;
-
     /**
      * @var int
      */
     private const INPUT_LINES_LIMIT = 200;
 
-    private function getInputLineLimit(): int
+    public function __construct(
+        private readonly ShortPhpLines $shortPhpLines
+    ) {
+    }
+
+    /**
+     * @param Closure(string):PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return self::INPUT_LINES_LIMIT;
+        $this->shortPhpLines->validate($value, $fail, self::INPUT_LINES_LIMIT);
     }
 }

--- a/src/Validation/Rules/ShortPhpConfigRule.php
+++ b/src/Validation/Rules/ShortPhpConfigRule.php
@@ -6,14 +6,14 @@ namespace App\Validation\Rules;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 
-final class ShortPhpContentsRule implements ValidationRule
+final class ShortPhpConfigRule implements ValidationRule
 {
     use ShortPhpLinesTrait;
 
     /**
      * @var int
      */
-    private const INPUT_LINES_LIMIT = 100;
+    private const INPUT_LINES_LIMIT = 200;
 
     private function getInputLineLimit(): int
     {

--- a/src/Validation/Rules/ShortPhpContentsRule.php
+++ b/src/Validation/Rules/ShortPhpContentsRule.php
@@ -4,19 +4,27 @@ declare(strict_types=1);
 
 namespace App\Validation\Rules;
 
+use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 final class ShortPhpContentsRule implements ValidationRule
 {
-    use ShortPhpLinesTrait;
-
     /**
      * @var int
      */
     private const INPUT_LINES_LIMIT = 100;
 
-    private function getInputLineLimit(): int
+    public function __construct(
+        private readonly ShortPhpLines $shortPhpLines
+    ) {
+    }
+
+    /**
+     * @param Closure(string):PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        return self::INPUT_LINES_LIMIT;
+        $this->shortPhpLines->validate($value, $fail, self::INPUT_LINES_LIMIT);
     }
 }

--- a/src/Validation/Rules/ShortPhpLines.php
+++ b/src/Validation/Rules/ShortPhpLines.php
@@ -7,27 +7,23 @@ namespace App\Validation\Rules;
 use Closure;
 use Illuminate\Translation\PotentiallyTranslatedString;
 
-/**
- * @internal
- * @method int getInputLineLimit()
- */
-trait ShortPhpLinesTrait
+final class ShortPhpLines
 {
     /**
      * @param Closure(string):PotentiallyTranslatedString $fail
      */
-    public function validate(string $attribute, mixed $value, Closure $fail): void
+    public function validate(mixed $value, Closure $fail, int $inputLimit): void
     {
         $newlineCount = substr_count((string) $value, "\n");
 
-        if ($newlineCount <= $this->getInputLineLimit()) {
+        if ($newlineCount <= $inputLimit) {
             return;
         }
 
         $errorMessage = sprintf(
             'Content file has %d lines. Reduce it under %d lines, to make it easier to read',
             $newlineCount,
-            $this->getInputLineLimit()
+            $inputLimit
         );
 
         $fail($errorMessage);

--- a/src/Validation/Rules/ShortPhpLinesTrait.php
+++ b/src/Validation/Rules/ShortPhpLinesTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Validation\Rules;
+
+use Closure;
+use Illuminate\Translation\PotentiallyTranslatedString;
+
+/**
+ * @internal
+ * @method int getInputLineLimit()
+ */
+trait ShortPhpLinesTrait
+{
+    /**
+     * @param Closure(string):PotentiallyTranslatedString $fail
+     */
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        $newlineCount = substr_count((string) $value, "\n");
+
+        if ($newlineCount <= $this->getInputLineLimit()) {
+            return;
+        }
+
+        $errorMessage = sprintf(
+            'Content file has %d lines. Reduce it under %d lines, to make it easier to read',
+            $newlineCount,
+            $this->getInputLineLimit()
+        );
+
+        $fail($errorMessage);
+    }
+}


### PR DESCRIPTION
Currently, there short maximum lines = 100 is on php contents, but on php config, it doesn't have this validation.

This PR add `ShortPhpConfigRule` for config rule, which the config validation config box, which shared with "Create custom rule" page to avoid too many lines added on the page.

This `ShortPhpConfigRule` have 200 lines maximum.
