### PR TITLE
Add links to rector sets from the filter results and rule detail pages

### DIFF
--- a/resources/views/homepage/rule-detail.blade.php
+++ b/resources/views/homepage/rule-detail.blade.php
@@ -80,9 +80,7 @@
                             SETS:&nbsp;
 
                             @foreach ($ruleMetadata->getSets() as $set)
-                                <a href="{{ action(\App\Controller\FilterRectorController::class, ['rectorSet' => $set->getSlug()]) }}">
-                                    <span class="badge bg-danger">{{ $set->getName() }}</span>
-                                </a>
+                                <a href="{{ action(\App\Controller\FilterRectorController::class, ['rectorSet' => $set->getSlug()]) }}"><span class="badge bg-danger">{{ $set->getName() }}</span></a>
                             @endforeach
                         </div>
                     @endif

--- a/resources/views/homepage/rule-detail.blade.php
+++ b/resources/views/homepage/rule-detail.blade.php
@@ -80,7 +80,9 @@
                             SETS:&nbsp;
 
                             @foreach ($ruleMetadata->getSets() as $set)
-                                <span class="badge bg-danger">{{ $set->getName() }}</span>
+                                <a href="{{ action(\App\Controller\FilterRectorController::class, ['rectorSet' => $set->getSlug()]) }}">
+                                    <span class="badge bg-danger">{{ $set->getName() }}</span>
+                                </a>
                             @endforeach
                         </div>
                     @endif

--- a/resources/views/livewire/rector-filter-component.blade.php
+++ b/resources/views/livewire/rector-filter-component.blade.php
@@ -103,9 +103,7 @@
                                 SETS:&nbsp;
 
                                 @foreach ($filteredRule->getSets() as $rectorSet)
-                                    <a href="{{ action(\App\Controller\FilterRectorController::class, ['rectorSet' => $rectorSet->getSlug()]) }}">
-                                        <span class="badge bg-danger">{{ $rectorSet->getName() }}</span>
-                                    </a>
+                                    <a href="{{ action(\App\Controller\FilterRectorController::class, ['rectorSet' => $rectorSet->getSlug()]) }}"><span class="badge bg-danger">{{ $rectorSet->getName() }}</span></a>
                                 @endforeach
                             </div>
                         @endif

--- a/resources/views/livewire/rector-filter-component.blade.php
+++ b/resources/views/livewire/rector-filter-component.blade.php
@@ -103,7 +103,9 @@
                                 SETS:&nbsp;
 
                                 @foreach ($filteredRule->getSets() as $rectorSet)
-                                    <span class="badge bg-danger">{{ $rectorSet->getName() }}</span>
+                                    <a href="{{ action(\App\Controller\FilterRectorController::class, ['rectorSet' => $rectorSet->getSlug()]) }}">
+                                        <span class="badge bg-danger">{{ $rectorSet->getName() }}</span>
+                                    </a>
                                 @endforeach
                             </div>
                         @endif


### PR DESCRIPTION
When you are searching for rules in the rule finder page and you find a rule which belongs to a set, you may want to know which other rules belong to that set.
In this PR we add links to the red badges with the set names which will take you straight to a list of all the rules that belong to that set