### PR TITLE
[Doc] Update cache in CI to use actions/cache@v4

### DIFF
--- a/resources/docs/cache-in-ci.md
+++ b/resources/docs/cache-in-ci.md
@@ -38,7 +38,7 @@ On GitHub Actions, you can use the [built-in cache action](https://github.com/ac
 
 ```yaml
       - name: Rector Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/rector
           key: ${{ runner.os }}-rector-${{ github.run_id }}


### PR DESCRIPTION
I can see in a project that actions/cache v3 got 2 minutes on "post cache", while actions/cache v4 got 3 seconds, so it may actions/cache v4 has some bug fix included, also recommend to use latest versions of actions/cache