### PR TITLE
Fix find rule community detail rule

### DIFF
--- a/src/FileSystem/RectorFinder.php
+++ b/src/FileSystem/RectorFinder.php
@@ -66,6 +66,12 @@ final class RectorFinder
             }
         }
 
+        foreach ($this->findCommunity() as $ruleMetadata) {
+            if ($ruleMetadata->getSlug() === $slug) {
+                return $ruleMetadata;
+            }
+        }
+
         return null;
     }
 


### PR DESCRIPTION
The `findBySlug()` should locate both core and community.

Fixes https://github.com/rectorphp/getrector-com/issues/2589