### PR TITLE
Fix mobile show "parse" button on /ast page

### DIFF
--- a/resources/views/ast/ast.blade.php
+++ b/resources/views/ast/ast.blade.php
@@ -35,10 +35,11 @@
                     </button>
                 </div>
 
+                <br /><br />
+
             </form>
         </div>
 
-        <br /><br />
         @if ($astRun instanceof \App\Ast\Entity\AstRun)
             @livewire('ast-component', ['astRun' => $astRun, 'inputFormContents' => $inputFormContents])
         @endif

--- a/resources/views/ast/ast.blade.php
+++ b/resources/views/ast/ast.blade.php
@@ -23,7 +23,7 @@
                     short PHP code you want to understand
                 </p>
 
-                <div style="margin-left:24em; margin-top: 13.5em; z-index: 100; position: absolute">
+                <div style="margin-left:1em; margin-top: 13.5em; z-index: 100; position: absolute">
                     <button type="submit" id="ast_form_process" name="process" class="btn btn-success">
                         Parse
                     </button>

--- a/resources/views/ast/ast.blade.php
+++ b/resources/views/ast/ast.blade.php
@@ -38,6 +38,7 @@
             </form>
         </div>
 
+        <br /><br />
         @if ($astRun instanceof \App\Ast\Entity\AstRun)
             @livewire('ast-component', ['astRun' => $astRun, 'inputFormContents' => $inputFormContents])
         @endif

--- a/resources/views/ast/ast.blade.php
+++ b/resources/views/ast/ast.blade.php
@@ -23,17 +23,17 @@
                     short PHP code you want to understand
                 </p>
 
-                <div style="margin-left:1em; margin-top: 13.5em; z-index: 100; position: absolute">
-                    <button type="submit" id="ast_form_process" name="process" class="btn btn-success">
-                        Parse
-                    </button>
-                </div>
-
                 @include('_snippets.form.form_textarea', [
                     'label' => null,
                     'inputName' => 'php_contents',
                     'defaultValue' => $inputFormContents,
                 ])
+
+                <div style="margin-left:0em; margin-top: 0em; z-index: 100; position: absolute">
+                    <button type="submit" id="ast_form_process" name="process" class="btn btn-success">
+                        Parse
+                    </button>
+                </div>
 
             </form>
         </div>


### PR DESCRIPTION
**Before**

![Screenshot 2025-01-25 at 20 04 18](https://github.com/user-attachments/assets/76ad3d78-e494-43f6-8f09-ae5bc32f5ae4)


**After**

![Screenshot 2025-01-25 at 20 07 55](https://github.com/user-attachments/assets/7a5e5870-0e9b-4109-9ae8-7a8690e3ba22)

I am not good at css, but here we go :)