### PR TITLE
[demo] Split code and diffs into 2 separate columns to avoid overflow

### DIFF
--- a/resources/views/_snippets/form/form_diff.blade.php
+++ b/resources/views/_snippets/form/form_diff.blade.php
@@ -8,7 +8,7 @@
 @if ($rectorRun->isSuccessful())
     <div class="col-6" style="float: right;" class="diff-snippet">
         @foreach ($rectorRun->getDiffSnippets() as $diffSnippet)
-            <pre style="position: absolute; z-index: 10; width: 32.7em; margin-top: {{ $diffSnippet->getLine() * 1.4 + 1.7 }}em"><code class="language-diff">{{ $diffSnippet->getSnippet() }}</code></pre>
+            <pre style="position: absolute; z-index: 10; width: 33.7em; margin-top: {{ $diffSnippet->getLine() * 1.4 + 1.7 }}em"><code class="language-diff">{{ $diffSnippet->getSnippet() }}</code></pre>
         @endforeach
     </div>
 @endif

--- a/resources/views/_snippets/form/form_fatal_errors.blade.php
+++ b/resources/views/_snippets/form/form_fatal_errors.blade.php
@@ -1,19 +1,21 @@
 @if ($rectorRun->hasRun() && $rectorRun->isSuccessful() !== true)
-    <div class="alert alert-danger mb-3">
-        <p>
-            <strong>Rector run Failed:</strong>
-        </p>
+    <div class="row">
+        <div class="alert alert-danger mb-3">
+            <p>
+                <strong>Rector run Failed:</strong>
+            </p>
 
-        {!! $rectorRun->getFatalErrorMessage() !!}
+            {!! $rectorRun->getFatalErrorMessage() !!}
 
-        @if ($rectorRun->getErrors() !== [])
-            <ul class="mt-3 ms-0 pl-4">
-                @foreach ($rectorRun->getErrors() as $error)
-                    <li>
-                        {{ $error }}
-                    </li>
-                @endforeach
-            </ul>
-        @endif
+            @if ($rectorRun->getErrors() !== [])
+                <ul class="mt-3 ms-0 pl-4">
+                    @foreach ($rectorRun->getErrors() as $error)
+                        <li>
+                            {{ $error }}
+                        </li>
+                    @endforeach
+                </ul>
+            @endif
+        </div>
     </div>
 @endif

--- a/resources/views/demo/demo.blade.php
+++ b/resources/views/demo/demo.blade.php
@@ -30,11 +30,11 @@
                 'defaultValue' => $rectorRun->getContent()
             ])
 
-            <div class="clearfix mb-3" style="clear: both"></div>
+            <div class="clearfix pb-0 mb-0" style="clear: both"></div>
 
             @if ($rectorRun->isSuccessful() && $rectorRun->getAppliedRules())
                 <div class="row">
-                    <div class="pt-0 pb-4 col-12 col-sm-6">
+                    <div class="pt-0 pb-2 col-12 col-sm-6">
                         <p class="mb-2">Applied Rules:</p>
 
                         <ul class="list-noindent">
@@ -46,17 +46,19 @@
                                 </li>
                             @endforeach
                         </ul>
-                    </div>
-                    <div class="pt-0 pb-4 col-12 col-sm-6">
-                        <p class="mb-2">Is the result wrong?</p>
-                        <a href="{{ issueLink($rectorRun) }}" class="btn btn-danger">Create an
-                            issue</a>
+
+                    <p class="mt-4 mb-2">Not a change you expect?</p>
+
+                    <ul>
+                        <li>
+                            <a href="{{ issueLink($rectorRun) }}" class="text-danger">Create an issue</a> on GitHub
+                        </li>
 
                         @if ($rectorRun->canCreateFixture())
-                            <a href="{{ pullRequestLink($rectorRun) }}"
-                               class="btn btn-primary ms-3">Create
-                                a Test</a>
+                            <li>...or to speed up fix &ndash; <a href="{{ pullRequestLink($rectorRun) }}"  class="text-success">add a test fixture</a>
+                            </li>
                         @endif
+                    </ul>
                     </div>
                 </div>
             @endif

--- a/src/FileSystem/RectorFinder.php
+++ b/src/FileSystem/RectorFinder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\FileSystem;
 
-use Throwable;
 use App\Exception\InvalidRuleDescriptionException;
 use App\RuleFilter\ValueObject\RectorSet;
 use App\RuleFilter\ValueObject\RuleMetadata;
@@ -15,6 +14,7 @@ use Rector\Contract\Rector\RectorInterface;
 use Rector\PostRector\Contract\Rector\PostRectorInterface;
 use ReflectionClass;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
+use Throwable;
 use Webmozart\Assert\Assert;
 
 final readonly class RectorFinder


### PR DESCRIPTION
Current solution uses `position: absolute` that disallows clearing div. That's why code overflows to next element.

The only path nows seems spliiting into 2 columns: one with origin code and 2nd with diffs.


![Screenshot From 2025-04-14 15-50-12](https://github.com/user-attachments/assets/aadf2eb8-f3f6-487e-b3f6-fca2bcb94568)


Closes https://github.com/rectorphp/getrector-com/issues/2957