### PR TITLE
Only show Dark/Light Theme bottom menu when on @isset ($codeMirror)

### DIFF
--- a/resources/views/_snippets/menu_items.blade.php
+++ b/resources/views/_snippets/menu_items.blade.php
@@ -46,7 +46,10 @@
            class="nav-link">Find rule</a>
     </li>
 
+    @isset ($codeMirror)
     <li class="nav-item">
         <a onclick="toggleTheme()" class="nav-link" id="theme_toggle" style="cursor: pointer">Dark/Light Theme</a>
     </li>
+    @endisset
+
 @endisset

--- a/resources/views/_snippets/styles.blade.php
+++ b/resources/views/_snippets/styles.blade.php
@@ -9,7 +9,6 @@
 {{-- pick from https://highlightjs.org/demo --}}
 
     <link rel="stylesheet" id="theme-link" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/base16/atlas.min.css">
-@endisset
 
 <style>
     pre code.hljs {
@@ -63,7 +62,6 @@
     window.onload = loadTheme;
 </script>
 
-@isset ($codeMirror)
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/bash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/php.min.js"></script>


### PR DESCRIPTION
Avoid error undefined `theme` javascript error, as only when codeMirror is set. 

```
[localhost:8000:56:22](http://localhost:8000/)
Uncaught TypeError: theme is null
    toggleTheme http://localhost:8000/:72
    onclick http://localhost:8000/:1
```