### PR TITLE
Re-add Dark/Light Theme link

### DIFF
--- a/resources/views/_snippets/menu_items.blade.php
+++ b/resources/views/_snippets/menu_items.blade.php
@@ -46,10 +46,8 @@
            class="nav-link">Find rule</a>
     </li>
 
-    @isset ($codeMirror)
     <li class="nav-item">
         <a onclick="toggleTheme()" class="nav-link" id="theme_toggle" style="cursor: pointer">Dark/Light Theme</a>
     </li>
-    @endisset
 
 @endisset

--- a/resources/views/_snippets/styles.blade.php
+++ b/resources/views/_snippets/styles.blade.php
@@ -1,4 +1,5 @@
 <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600&display=swap" rel="stylesheet">
+<link rel="stylesheet" id="theme-link" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/base16/atlas.min.css">
 
 @isset ($codeMirror)
     {{-- live code highligh in demo --}}
@@ -7,8 +8,7 @@
 
 {{-- code highligh posts --}}
 {{-- pick from https://highlightjs.org/demo --}}
-
-    <link rel="stylesheet" id="theme-link" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/styles/base16/atlas.min.css">
+@endisset
 
 <style>
     pre code.hljs {
@@ -62,6 +62,7 @@
     window.onload = loadTheme;
 </script>
 
+@isset ($codeMirror)
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/bash.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/languages/php.min.js"></script>


### PR DESCRIPTION
@TomasVotruba per review:

- https://github.com/rectorphp/getrector-com/pull/3006#issuecomment-2842744935

The id="theme-link" needs to be exists to avoid error:

```
[localhost:8000:56:22](http://localhost:8000/)
Uncaught TypeError: theme is null
    toggleTheme http://localhost:8000/:72
    onclick http://localhost:8000/:1
```