### PR TITLE
[Docs] Add docs for troubleshoot preload conflict on phpunit 12+

### DIFF
--- a/resources/docs/troubleshooting-preload.md
+++ b/resources/docs/troubleshooting-preload.md
@@ -1,0 +1,28 @@
+On some dependency with CLI command, eg: PHPUnit 12+, you may got error:
+
+```bash
+PHP Fatal error:  Cannot declare interface PhpParser\NodeVisitor, because the name is already in use in /home/runner/work/rector-rules/rector-rules/vendor/rector/rector/vendor/nikic/php-parser/lib/PhpParser/NodeVisitor.php on line 6
+```
+
+which its own autoload too early loaded, you may need to handle it with register `rector` preload.php under `"autoload-dev" -> "files"` like below:
+
+```json
+{
+    "autoload-dev": {
+        "psr-4": {
+            "Your\\Test\\": "tests/"
+        },
+        "files": [
+            "vendor/rector/rector/preload.php"
+        ]
+    }
+}
+```
+
+then, run:
+
+```bash
+composer update
+```
+
+and verify it resolved.

--- a/src/Documentation/DocumentationMenuFactory.php
+++ b/src/Documentation/DocumentationMenuFactory.php
@@ -56,6 +56,10 @@ final readonly class DocumentationMenuFactory
                     'Troubleshooting Parallel'
                 ),
                 $this->documentationMenuItemFactory->createSection(
+                    'troubleshooting-preload',
+                    'Troubleshooting Preload PHPParser and PHPStan PHPDoc Parser'
+                ),
+                $this->documentationMenuItemFactory->createSection(
                     'reporting-issue-with-rector',
                     'Reporting Issue With Rector'
                 ),


### PR DESCRIPTION
@ostrolucky @TomasVotruba this is new documentation section for troubleshooting preload conflict on phpunit 12+

Ref 

- https://github.com/rectorphp/rector/issues/9242
- https://github.com/ostrolucky/rector-rules/pull/44