### PR TITLE
Add nikic/php-parser to composer update on daily pull request update

### DIFF
--- a/.github/workflows/daily_pull_request_automatic_update.yaml
+++ b/.github/workflows/daily_pull_request_automatic_update.yaml
@@ -17,7 +17,7 @@ jobs:
                 actions:
                     -
                         name: "Update Rector Dependencies"
-                        run: "composer update rector/rector phpstan/phpdoc-parser --with-all-dependencies"
+                        run: "composer update rector/rector nikic/php-parser --with-all-dependencies"
                         branch: 'automated-regenerated-composer-lock'
 
         name: ${{ matrix.actions.name }}


### PR DESCRIPTION
To avoid miss update like this PR:

- https://github.com/rectorphp/getrector-com/pull/3226

also, `phpstan/phpdoc-parser` is not in dependencies, so can be removed.


```
➜  getrector-com git:(bump-php-parser) composer show phpstan/phpdoc-parser

In ShowCommand.php line 325:
                                                                                                         
  Package "phpstan/phpdoc-parser" not found, try using --available (-a) to show all available packages.                                                                                                 
```
