### PR TITLE
feat: add ability to discover rules not in a set

### DIFF
--- a/resources/views/livewire/find-rule-component.blade.php
+++ b/resources/views/livewire/find-rule-component.blade.php
@@ -56,6 +56,10 @@
                 @else
                     <option value="">All sets</option>
 
+                    <option value="{{ \App\RuleFilter\RuleFilter::NOT_IN_SET }}">
+                        Rules not in a set ({{ $rulesNotInSetCount }})
+                    </option>
+
                     @foreach ($rectorSets as $rectorSet)
                         <option value="{{ $rectorSet->getSlug() }}">
                             {{ $rectorSet->getName() }}

--- a/src/FileSystem/RectorFinder.php
+++ b/src/FileSystem/RectorFinder.php
@@ -35,6 +35,15 @@ final readonly class RectorFinder
     }
 
     /**
+     * @api
+     * @return RuleMetadata[]
+     */
+    public function find(): array
+    {
+        return [...$this->findCore(), ...$this->findCommunity()];
+    }
+
+    /**
      * @api to be used
      * @return RuleMetadata[]
      */

--- a/src/Livewire/FindRuleComponent.php
+++ b/src/Livewire/FindRuleComponent.php
@@ -49,6 +49,7 @@ final class FindRuleComponent extends Component
             'queryExamples' => FindRuleQuery::EXAMPLES,
             'rectorSets' => $rectorSets,
             'activeRectorSetGroup' => $this->activeRectorSetGroup,
+            'rulesNotInSetCount' => $this->countRulesNotInSet(),
             'rectorSetGroups' => [
                 null => 'Any group',
                 GroupName::PHP => 'PHP',
@@ -96,5 +97,19 @@ final class FindRuleComponent extends Component
 
         // log only meaningful query, not a start of typing, to keep data clean
         $rectorFuleSearchLogger->log($this->query, $this->activeRectorSetGroup, $this->rectorSet);
+    }
+
+    private function countRulesNotInSet(): int
+    {
+        if ($this->activeRectorSetGroup === null) {
+            return 0;
+        }
+
+        /** @var RectorFinder $rectorFinder */
+        $rectorFinder = app(RectorFinder::class);
+        /** @var RuleFilter $ruleFilter */
+        $ruleFilter = app(RuleFilter::class);
+
+        return count($ruleFilter->filter($rectorFinder->find(), null, RuleFilter::NOT_IN_SET, $this->activeRectorSetGroup));
     }
 }

--- a/src/Livewire/FindRuleComponent.php
+++ b/src/Livewire/FindRuleComponent.php
@@ -83,12 +83,10 @@ final class FindRuleComponent extends Component
     {
         /** @var RectorFinder $rectorFinder */
         $rectorFinder = app(RectorFinder::class);
-        $ruleMetadatas = array_merge($rectorFinder->findCore(), $rectorFinder->findCommunity());
-
         /** @var RuleFilter $ruleFilter */
         $ruleFilter = app(RuleFilter::class);
 
-        return $ruleFilter->filter($ruleMetadatas, $this->query, $this->rectorSet, $this->activeRectorSetGroup);
+        return $ruleFilter->filter($rectorFinder->find(), $this->query, $this->rectorSet, $this->activeRectorSetGroup);
     }
 
     private function logRuleSearchIfUseful(): void

--- a/src/RuleFilter/RuleFilter.php
+++ b/src/RuleFilter/RuleFilter.php
@@ -11,6 +11,8 @@ use App\Sets\RectorSetsTreeProvider;
 
 final readonly class RuleFilter
 {
+    public const string NOT_IN_SET = ':not-in-set';
+
     private const int MAX_RESULTS = 10;
 
     public function __construct(
@@ -92,6 +94,13 @@ final readonly class RuleFilter
     {
         if ($set === '' || $set === null) {
             return $ruleMetadatas;
+        }
+
+        if ($set === self::NOT_IN_SET) {
+            return array_filter(
+                $ruleMetadatas,
+                fn (RuleMetadata $ruleMetadata): bool => ! $ruleMetadata->isPartOfSets()
+            );
         }
 
         /** @var RectorSetsTreeProvider $rectorSetsTreeProvider */

--- a/src/RuleFilter/RuleFilter.php
+++ b/src/RuleFilter/RuleFilter.php
@@ -24,9 +24,9 @@ final readonly class RuleFilter
      */
     public function filter(array $ruleMetadatas, ?string $query, ?string $set, ?string $setGroup): array
     {
-        $ruleMetadatas = $this->filterByQuery($ruleMetadatas, $query);
-        $ruleMetadatas = $this->filterBySet($ruleMetadatas, $set);
         $ruleMetadatas = $this->filterBySetGroup($ruleMetadatas, $setGroup);
+        $ruleMetadatas = $this->filterBySet($ruleMetadatas, $set);
+        $ruleMetadatas = $this->filterByQuery($ruleMetadatas, $query);
 
         $maxResults = self::MAX_RESULTS;
         if ($setGroup || $set) {


### PR DESCRIPTION
Hello!

Closes https://github.com/rectorphp/rector/issues/9299, closes https://github.com/driftingly/rector-laravel/issues/342

It has been very difficult to discover rules that are not a part of any set (unless you just happening to be searching the name). This PR adds a `Rules not in set` pseudo-selector that will show all of the rules in a group that are not in a set.


<details>
<summary>Screenshots</summary>

<img width="2226" height="668" alt="image" src="https://github.com/user-attachments/assets/13c26eac-921e-41e3-9b50-244a4dc4fb15" />

<img width="2226" height="668" alt="image" src="https://github.com/user-attachments/assets/09451ec4-2fae-49cc-8cc9-564dd7c4083e" />

<img width="2226" height="668" alt="image" src="https://github.com/user-attachments/assets/e0d1a92c-a8e0-406c-b51a-82f0fb2a3483" />


</details>

Additionally, I made a performance improvement to help filter sets faster.

Thanks!